### PR TITLE
Date search

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,6 @@ run-frontend:
 # Run this command with "make run -j2", that way backend and frontend run simultaneously
 run: run-backend run-frontend
 
+# Only runs backend tests (currently there are no frontend tests anyway)
+test:
+	cd backend && $(MAKE) test

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -3,5 +3,9 @@ install:
 	env/bin/pip install -e .[dev]
 
 run:
-	FLASK_APP=backend.app ELOGY_CONFIG_FILE=../config.py env/bin/flask run -p 8888
+	FLASK_APP=backend.app ELOGY_CONFIG_FILE=../config.py env/bin/flask run -p 8888 --reload
 
+# Skip performance tests because they are slow.
+.PHONY: test
+test:
+	env/bin/pytest test -k 'not performance'

--- a/backend/backend/api/entries.py
+++ b/backend/backend/api/entries.py
@@ -138,8 +138,8 @@ entries_args = {
     "attachments": Str(),
     "attribute": List(Str(validate=lambda s: len(s.split(":")) == 2)),
     "metadata": List(Str(validate=lambda s: len(s.split(":")) == 2)),
-    "from_date": Date(),
-    "to_date": Date(),
+    "from": LocalDateTime(),
+    "until": LocalDateTime(),
     "archived": Boolean(),
     "ignore_children": Boolean(),
     "n": Integer(missing=50),
@@ -171,8 +171,8 @@ class EntriesResource(Resource):
                                attachment_filter=args.get("attachments"),
                                attribute_filter=attributes,
                                metadata_filter=metadata,
-                               from_date=args.get("from_date"),
-                               to_date=args.get("to_date"),
+                               from_timestamp=args.get("from"),
+                               until_timestamp=args.get("until"),
                                n=args["n"], offset=args.get("offset"),
                                sort_by_timestamp=args.get("sort_by_timestamp"))
             entries = logbook.get_entries(**search_args)
@@ -186,8 +186,8 @@ class EntriesResource(Resource):
                                attachment_filter=args.get("attachments"),
                                attribute_filter=attributes,
                                metadata_filter=metadata,
-                               from_date=args.get("from_date"),
-                               to_date=args.get("to_date"),
+                               from_timestamp=args.get("from"),
+                               until_timestamp=args.get("until"),
                                n=args["n"], offset=args.get("offset"),
                                sort_by_timestamp=args.get("sort_by_timestamp"))
             entries = Entry.search(**search_args)

--- a/backend/backend/api/entries.py
+++ b/backend/backend/api/entries.py
@@ -3,7 +3,7 @@ import logging
 from flask import request, send_file
 from flask_restful import Resource, marshal, marshal_with, abort
 from webargs.fields import (Integer, Str, Boolean, Dict, List,
-                            Nested, Email, LocalDateTime)
+                            Nested, Email, LocalDateTime, Date)
 from webargs.flaskparser import use_args
 
 from ..db import Entry, Logbook, EntryLock
@@ -138,6 +138,8 @@ entries_args = {
     "attachments": Str(),
     "attribute": List(Str(validate=lambda s: len(s.split(":")) == 2)),
     "metadata": List(Str(validate=lambda s: len(s.split(":")) == 2)),
+    "from_date": Date(),
+    "to_date": Date(),
     "archived": Boolean(),
     "ignore_children": Boolean(),
     "n": Integer(missing=50),
@@ -169,6 +171,8 @@ class EntriesResource(Resource):
                                attachment_filter=args.get("attachments"),
                                attribute_filter=attributes,
                                metadata_filter=metadata,
+                               from_date=args.get("from_date"),
+                               to_date=args.get("to_date"),
                                n=args["n"], offset=args.get("offset"),
                                sort_by_timestamp=args.get("sort_by_timestamp"))
             entries = logbook.get_entries(**search_args)
@@ -182,6 +186,8 @@ class EntriesResource(Resource):
                                attachment_filter=args.get("attachments"),
                                attribute_filter=attributes,
                                metadata_filter=metadata,
+                               from_date=args.get("from_date"),
+                               to_date=args.get("to_date"),
                                n=args["n"], offset=args.get("offset"),
                                sort_by_timestamp=args.get("sort_by_timestamp"))
             entries = Entry.search(**search_args)

--- a/backend/backend/app.py
+++ b/backend/backend/app.py
@@ -24,7 +24,7 @@ app = Flask(__name__,
             static_url_path="/static")
 app.config.from_envvar('ELOGY_CONFIG_FILE')
 
-app.secret_key = app.config["SECRET"]
+app.secret_key = app.config.get("SECRET", "not-very-secret")
 
 # add some hooks for debugging purposes
 @app.before_request

--- a/backend/test/fixtures.py
+++ b/backend/test/fixtures.py
@@ -19,7 +19,7 @@ def elogy(request):
     os.environ["ELOGY_CONFIG_FILE"] = "../test/config.py"
 
     def run_elogy():
-        from elogy.app import app
+        from backend.app import app
         app.run()
 
     proc = Process(target=run_elogy)
@@ -33,7 +33,7 @@ def elogy(request):
 @pytest.fixture(scope="function")
 def db(request):
 
-    from elogy.db import db, setup_database
+    from backend.db import db, setup_database
 
     setup_database(":memory:", close=False)
     return db
@@ -45,7 +45,7 @@ def db(request):
 @pytest.fixture(scope="module")
 def elogy_client(request):
     os.environ["ELOGY_CONFIG_FILE"] = "../test/config.py"
-    from elogy.app import app
+    from backend.app import app
     with app.test_client() as c:
         yield c
     try:

--- a/backend/test/test_api.py
+++ b/backend/test/test_api.py
@@ -135,7 +135,6 @@ def test_update_entry(elogy_client):
         elogy_client.put("/api/logbooks/{logbook[id]}/entries/{entry[id]}/"
                          .format(logbook=logbook, entry=entry),
                          data=new_in_entry))["entry"]
-    print(out_entry)
     assert out_entry["title"] == new_in_entry["title"]
     assert out_entry["content"] == new_in_entry["content"]
     assert out_entry["id"] == entry["id"]
@@ -159,7 +158,7 @@ def test_update_entry(elogy_client):
         elogy_client.get(
             "/api/logbooks/{logbook[id]}/entries/{entry[id]}/revisions/"
             .format(logbook=logbook, entry=entry)))["entry_changes"]
-
+    assert len(revisions) == 1
 
 def test_move_entry(elogy_client):
     in_logbook1, logbook1 = make_logbook(elogy_client)
@@ -188,7 +187,6 @@ def test_move_entry(elogy_client):
         elogy_client.get(
             "/api/entries/{entry[id]}/revisions/0"
             .format(entry=entry)))["entry"]
-    print(old_entry_version)
     assert old_entry_version["logbook"]["id"] == logbook1["id"]
     assert old_entry_version["revision_n"] == 0
 
@@ -196,6 +194,7 @@ def test_move_entry(elogy_client):
         elogy_client.get(
             "/api/logbooks/{logbook[id]}/entries/{entry[id]}/revisions/"
             .format(logbook=logbook2, entry=entry)))["entry_changes"]
+    assert len(revisions) == 1
 
 
 def test_create_entry_followup(elogy_client):
@@ -463,7 +462,7 @@ def test_create_attachment_with_single_quotes(elogy_client):
 
 def test_entry_search(elogy_client):
 
-    # TODO: expand to cover all ways to search
+    # TODO: expand to cover all ways to search, in various permutations
 
     # create a bunch of logbooks and entries
     in_logbook1, logbook1 = make_logbook(elogy_client)

--- a/backend/test/test_db.py
+++ b/backend/test/test_db.py
@@ -316,6 +316,12 @@ def test_entry_date_search(db):
     entries = [
         {
             "logbook": lb,
+            "title": "Z",
+            "content": "This content is great!",
+            "created_at": datetime(2019, 1, 14, 12, 0, 0)
+        },
+        {
+            "logbook": lb,
             "title": "A",
             "content": "This content is great!",
             "created_at": datetime(2019, 1, 15, 12, 0, 0)
@@ -330,7 +336,14 @@ def test_entry_date_search(db):
             "logbook": lb,
             "title": "C",
             "content": "Not so bad content either.",
-            "created_at": datetime(2019, 1, 19, 12, 0, 0)
+            "created_at": datetime(2019, 1, 18, 12, 0, 0)
+        },
+        {
+            "logbook": lb,
+            "title": "C",
+            "content": "Not so bad content either.",
+            "created_at": datetime(2019, 1, 19, 12, 0, 0),
+            "last_changed_at": datetime(2019, 2, 6, 12, 0, 0)
         }
     ]
 
@@ -340,17 +353,22 @@ def test_entry_date_search(db):
         entry.save()
 
     # include the from date
-    results = list(Entry.search(logbook=lb, from_date="2019-01-17"))
+    results = list(Entry.search(logbook=lb, from_timestamp="2019-01-17 00:00:00"))
     assert {r.title for r in results} == {"B", "C"}
 
-    # exclude the to date
-    # TODO does this make sense or should we include the date?
-    results = list(Entry.search(logbook=lb, to_date="2019-01-17"))
-    assert {r.title for r in results} == {"A"}
+    # include the until_date
+    results = list(Entry.search(logbook=lb, until_timestamp="2019-01-17 23:59:59"))
+    assert {r.title for r in results} == {"Z", "A", "B"}
 
     # date interval
-    results = list(Entry.search(logbook=lb, from_date="2019-01-16", to_date="2019-01-18"))
-    assert {r.title for r in results} == {"B"}
+    results = list(Entry.search(logbook=lb,
+                                from_timestamp="2019-01-15 00:00:00",
+                                until_timestamp="2019-01-17 23:59:59"))
+    assert {r.title for r in results} == {"A", "B"}
+
+    # also looks at change timestamp
+    results = list(Entry.search(logbook=lb, from_timestamp="2019-02-01"))
+    assert {r.title for r in results} == {"C"}
 
 
 def test_entry_search_followups(db):

--- a/backend/test/test_db.py
+++ b/backend/test/test_db.py
@@ -353,21 +353,21 @@ def test_entry_date_search(db):
         entry.save()
 
     # include the from date
-    results = list(Entry.search(logbook=lb, from_timestamp="2019-01-17 00:00:00"))
+    results = list(Entry.search(logbook=lb, from_timestamp=datetime(2019, 1, 17, 0, 0, 0)))
     assert {r.title for r in results} == {"B", "C"}
 
     # include the until_date
-    results = list(Entry.search(logbook=lb, until_timestamp="2019-01-17 23:59:59"))
+    results = list(Entry.search(logbook=lb, until_timestamp=datetime(2019, 1, 17, 23, 59, 59)))
     assert {r.title for r in results} == {"Z", "A", "B"}
 
     # date interval
     results = list(Entry.search(logbook=lb,
-                                from_timestamp="2019-01-15 00:00:00",
-                                until_timestamp="2019-01-17 23:59:59"))
+                                from_timestamp=datetime(2019, 1, 15, 0, 0, 0),
+                                until_timestamp=datetime(2019, 1, 17, 23, 59, 59)))
     assert {r.title for r in results} == {"A", "B"}
 
     # also looks at change timestamp
-    results = list(Entry.search(logbook=lb, from_timestamp="2019-02-01"))
+    results = list(Entry.search(logbook=lb, from_timestamp=datetime(2019, 2, 1)))
     assert {r.title for r in results} == {"C"}
 
 

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -55,7 +55,6 @@ class NoEntry extends React.Component {
 
     render() {
         const logbookId = parseInt(this.props.match.params.logbookId);
-        console.log(this.props.match.location);
         return (
             <div className="empty">
                 <i className="fa fa-arrow-left" /> Select an entry to read it

--- a/frontend/src/logbook.js
+++ b/frontend/src/logbook.js
@@ -194,7 +194,7 @@ class Logbook extends React.Component {
                 ? parseInt(this.props.match.params.entryId, 10)
                 : null,
             query = parseQuery(this.props.location.search),
-            filter = ["title", "content", "authors", "attachments", "from_date", "to_date"]
+            searchFilters = ["title", "content", "authors", "attachments", "from", "until"]
                 .filter(key => query[key])
                 .map(key => (
                     <span key={key} className="filter">
@@ -280,7 +280,7 @@ class Logbook extends React.Component {
                             New logbook
                         </Link>
                     </div>
-                    <div className="filters"> {filter} </div>
+                    <div className="filters"> {searchFilters} </div>
                     <div className="attributes">{attributes}</div>
                     { this.state.entries.length === 0 ? null : 
                         <div className="date-sorting">

--- a/frontend/src/logbook.js
+++ b/frontend/src/logbook.js
@@ -194,7 +194,7 @@ class Logbook extends React.Component {
                 ? parseInt(this.props.match.params.entryId, 10)
                 : null,
             query = parseQuery(this.props.location.search),
-            filter = ["title", "content", "authors", "attachments"]
+            filter = ["title", "content", "authors", "attachments", "from_date", "to_date"]
                 .filter(key => query[key])
                 .map(key => (
                     <span key={key} className="filter">

--- a/frontend/src/search.js
+++ b/frontend/src/search.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { Route } from "react-router-dom";
-import { parseQuery } from "./util.js";
+import { parseQuery, formatISODateString, getLocalTimezoneOffset } from "./util.js";
 import "./search.css";
 
 class QuickSearch extends React.Component {
@@ -126,8 +126,8 @@ class QuickSearch extends React.Component {
                                     <td>
                                         <input type="date"
                                             name="from"
-                                            value={this.state.from || ""}
-                                            max={this.state.until || ""}
+                                            value={ this.state.from }
+                                            max={ this.state.until }
                                             onChange={this.onChange.bind(this)}
                                             title="Only entries created/changed on or after this date."
                                         />
@@ -140,8 +140,8 @@ class QuickSearch extends React.Component {
                                     <td>
                                         <input type="date"
                                             name="until"
-                                            value={this.state.until || ""}
-                                            min={this.state.from || ""}
+                                            value={ this.state.until }
+                                            min={ this.state.from }
                                             onChange={this.onChange.bind(this)}
                                             title="Only entries created/changed before this date."
                                         />

--- a/frontend/src/search.js
+++ b/frontend/src/search.js
@@ -11,8 +11,8 @@ class QuickSearch extends React.Component {
             title: null,
             authors: null,
             attachments: null,
-            from_date: null,
-            to_date: null,
+            from: null,
+            until: null,
             ignore_children: false
         };
     }
@@ -56,8 +56,8 @@ class QuickSearch extends React.Component {
                 title: null,
                 authors: null,
                 attachments: null,
-                from_date: null,
-                to_date: null,
+                from: null,
+                to: null,
                 ignore_children: false
             },
             this.onSubmit.bind(this, history, event)
@@ -125,25 +125,25 @@ class QuickSearch extends React.Component {
                                     <td>From:</td>
                                     <td>
                                         <input type="date"
-                                            name="from_date"
-                                            value={this.state.from_date || ""}
-                                            max={this.state.to_date || ""}
+                                            name="from"
+                                            value={this.state.from || ""}
+                                            max={this.state.until || ""}
                                             onChange={this.onChange.bind(this)}
-                                            title="Only entries from on or after this date."
+                                            title="Only entries created/changed on or after this date."
                                         />
                                     </td>
                                 </tr>
                                 <tr>
                                     <td>
-                                        To:
+                                        Until:
                                     </td>
                                     <td>
                                         <input type="date"
-                                            name="to_date"
-                                            value={this.state.to_date || ""}
-                                            min={this.state.from_date || ""}
+                                            name="until"
+                                            value={this.state.until || ""}
+                                            min={this.state.from || ""}
                                             onChange={this.onChange.bind(this)}
-                                            title="Only entries from before this date."
+                                            title="Only entries created/changed before this date."
                                         />
                                     </td>                                    
                                 </tr>

--- a/frontend/src/search.js
+++ b/frontend/src/search.js
@@ -129,6 +129,7 @@ class QuickSearch extends React.Component {
                                             value={this.state.from_date || ""}
                                             max={this.state.to_date || ""}
                                             onChange={this.onChange.bind(this)}
+                                            title="Only entries from on or after this date."
                                         />
                                     </td>
                                 </tr>
@@ -142,6 +143,7 @@ class QuickSearch extends React.Component {
                                             value={this.state.to_date || ""}
                                             min={this.state.from_date || ""}
                                             onChange={this.onChange.bind(this)}
+                                            title="Only entries from before this date."
                                         />
                                     </td>                                    
                                 </tr>

--- a/frontend/src/search.js
+++ b/frontend/src/search.js
@@ -11,6 +11,8 @@ class QuickSearch extends React.Component {
             title: null,
             authors: null,
             attachments: null,
+            from_date: null,
+            to_date: null,
             ignore_children: false
         };
     }
@@ -54,6 +56,8 @@ class QuickSearch extends React.Component {
                 title: null,
                 authors: null,
                 attachments: null,
+                from_date: null,
+                to_date: null,
                 ignore_children: false
             },
             this.onSubmit.bind(this, history, event)
@@ -115,6 +119,34 @@ class QuickSearch extends React.Component {
                             placeholder="Attachments"
                             onChange={this.onChange.bind(this)}
                         />
+                        <table>
+                            <tbody>
+                                <tr>
+                                    <td>From:</td>
+                                    <td>
+                                        <input type="date"
+                                            name="from_date"
+                                            value={this.state.from_date || ""}
+                                            max={this.state.to_date || ""}
+                                            onChange={this.onChange.bind(this)}
+                                        />
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        To:
+                                    </td>
+                                    <td>
+                                        <input type="date"
+                                            name="to_date"
+                                            value={this.state.to_date || ""}
+                                            min={this.state.from_date || ""}
+                                            onChange={this.onChange.bind(this)}
+                                        />
+                                    </td>                                    
+                                </tr>
+                            </tbody>
+                        </table>
                         <label title="Whether to include entries in logbooks contained in the selected logbook.">
                             <input
                                 type="checkbox"

--- a/frontend/src/search.js
+++ b/frontend/src/search.js
@@ -57,7 +57,7 @@ class QuickSearch extends React.Component {
                 authors: null,
                 attachments: null,
                 from: null,
-                to: null,
+                until: null,
                 ignore_children: false
             },
             this.onSubmit.bind(this, history, event)
@@ -126,7 +126,7 @@ class QuickSearch extends React.Component {
                                     <td>
                                         <input type="date"
                                             name="from"
-                                            value={ this.state.from }
+                                            value={ this.state.from || "" }
                                             max={ this.state.until }
                                             onChange={this.onChange.bind(this)}
                                             title="Only entries created/changed on or after this date."
@@ -140,7 +140,7 @@ class QuickSearch extends React.Component {
                                     <td>
                                         <input type="date"
                                             name="until"
-                                            value={ this.state.until }
+                                            value={ this.state.until || "" }
                                             min={ this.state.from }
                                             onChange={this.onChange.bind(this)}
                                             title="Only entries created/changed before this date."


### PR DESCRIPTION
Adds two date fields to the search options, one "from" and one "until". These will limit the results to those created or edited between these dates (if specified). AFAICT, the date input should be pretty well supported in browsers these days.

The "until" date is not inclusive, meaning that only entries from *before* that date are included. Not sure if that is intuitive, it was just the simplest to implement.

Also, there might be some complexity around timestamps, I've tried to address it but it's not well tested.

As a bonus, I've fixed the test suite, and there's now a "make test" target (assumes "pytest" is installed).