### PR TITLE
New try at HTML/PDF export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 .gitignore
 
 frontend/node_modules
+frontend/build
+attachments
+__pycache__
+backend/env

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,7 +3,8 @@ FROM tiangolo/uwsgi-nginx:python3.6
 RUN apt-get update && \
 	apt-get install -y \
 	libldap2-dev \
-	libsasl2-dev
+        libsasl2-dev \
+        wkhtmltopdf
 
 RUN mkdir /app/elogy
 
@@ -20,4 +21,4 @@ RUN mkdir /var/elogy/attachments
 
 EXPOSE 80
 
-ENTRYPOINT ["uwsgi", "--socket=0.0.0.0:80", "--protocol=http", "--file=run.py", "--callable=app"]
+ENTRYPOINT ["uwsgi", "--socket=0.0.0.0:80", "--protocol=http", "--file=run.py", "--callable=app", "--wsgi-disable-file-wrapper"]

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -3,5 +3,4 @@ install:
 	env/bin/pip install -e .[dev]
 
 run:
-	FLASK_APP=backend.app ELOGY_CONFIG_FILE=../config.py env/bin/flask run -p 8888
-
+	FLASK_APP=backend.app ELOGY_CONFIG_FILE=../config.py env/bin/flask run -p 8888 --reload --debugger

--- a/backend/backend/api/entries.py
+++ b/backend/backend/api/entries.py
@@ -1,5 +1,4 @@
-import logging
-from slugify import slugify
+import io
 
 from flask import request, send_file
 from flask_restful import Resource, marshal, marshal_with, abort
@@ -9,7 +8,7 @@ from webargs.flaskparser import use_args
 
 from ..db import Entry, Logbook, EntryLock
 from ..attachments import handle_img_tags
-from ..export import export_entries_as_pdf, export_entries_as_html
+from ..export import export_entries
 from ..actions import new_entry, edit_entry
 from . import fields, send_signal
 
@@ -142,9 +141,10 @@ entries_args = {
     "archived": Boolean(),
     "ignore_children": Boolean(),
     "n": Integer(missing=50),
-    "offset": Integer(),
+    "offset": Integer(missing=0),
     "download": Str(),
     "sort_by_timestamp": Boolean(missing=True),
+    "reverse_order": Boolean(missing=True)
 }
 
 
@@ -160,6 +160,9 @@ class EntriesResource(Resource):
         metadata = [meta.split(":")
                     for meta in args.get("metadata", [])]
 
+        n_entries = args["n"]
+        offset = args["offset"]
+
         if logbook_id:
             # restrict search to the given logbook and its descendants
             logbook = Logbook.get(Logbook.id == logbook_id)
@@ -170,8 +173,9 @@ class EntriesResource(Resource):
                                attachment_filter=args.get("attachments"),
                                attribute_filter=attributes,
                                metadata_filter=metadata,
-                               n=args["n"], offset=args.get("offset"),
-                               sort_by_timestamp=args.get("sort_by_timestamp"))
+                               n=n_entries, offset=offset,
+                               sort_by_timestamp=args.get("sort_by_timestamp"),
+                               reverse_order=args.get("reverse_order"))
             entries = logbook.get_entries(**search_args)
         else:
             # global search (all logbooks)
@@ -183,33 +187,26 @@ class EntriesResource(Resource):
                                attachment_filter=args.get("attachments"),
                                attribute_filter=attributes,
                                metadata_filter=metadata,
-                               n=args["n"], offset=args.get("offset"),
-                               sort_by_timestamp=args.get("sort_by_timestamp"))
+                               n=n_entries, offset=offset,
+                               sort_by_timestamp=args.get("sort_by_timestamp"),
+                               reverse_order=args.get("reverse_order"))
             entries = Entry.search(**search_args)
 
-        if args.get("download") == "pdf":
-            # return a PDF version
-            # TODO: not sure if this belongs in the API
-            pdf = export_entries_as_pdf(logbook, entries)
-            if pdf is None:
-                abort(400, message="Could not create PDF!")
-            return send_file(pdf, mimetype="application/pdf",
-                             as_attachment=True,
-                             attachment_filename=("{logbook.name}.pdf"
-                                                  .format(logbook=logbook)))
-        elif args.get("download") == "html":
-            # return a PDF version
-            # TODO: not sure if this belongs in the API
-            html = export_entries_as_html(logbook, entries)
-            if html is None:
-                abort(400, message="Could not create HTML!")
-            return send_file(html, mimetype="text/html",
-                             as_attachment=True,
-                             attachment_filename=(slugify("{logbook.name}.html"
-                                                  .format(logbook=logbook))))
+        if args.get("download"):
+            # Allow getting the entries as one big file (html or pdf), to go.
+            try:
+                data, real_n_entries, mimetype, filename = export_entries(
+                    logbook, entries, n_entries, offset, args["download"])
+            except ValueError:
+                abort(400)
+            buf = io.BytesIO()
+            buf.write(data)
+            buf.seek(0)
+            return send_file(buf, mimetype=mimetype, as_attachment=True,
+                             attachment_filename=filename)
 
-        return marshal(dict(logbook=logbook,
-                            entries=list(entries)), fields.entries)
+        return marshal(dict(logbook=logbook, entries=list(entries)),
+                       fields.entries)
 
 
 class EntryLockResource(Resource):

--- a/backend/backend/api/entries.py
+++ b/backend/backend/api/entries.py
@@ -1,4 +1,5 @@
 import logging
+from slugify import slugify
 
 from flask import request, send_file
 from flask_restful import Resource, marshal, marshal_with, abort
@@ -202,10 +203,12 @@ class EntriesResource(Resource):
             html = export_entries_as_html(logbook, entries)
             if html is None:
                 abort(400, message="Could not create HTML!")
-            return send_file(html, mimetype="text/html",
+            ret = send_file(html.name, mimetype="text/html",
                              as_attachment=True,
-                             attachment_filename=("{logbook.name}.html"
-                                                  .format(logbook=logbook)))
+                             attachment_filename=(slugify("{logbook.name}.html"
+                                                  .format(logbook=logbook))))
+            html.close()
+            return ret
 
         return marshal(dict(logbook=logbook,
                             entries=list(entries)), fields.entries)

--- a/backend/backend/api/entries.py
+++ b/backend/backend/api/entries.py
@@ -8,7 +8,7 @@ from webargs.flaskparser import use_args
 
 from ..db import Entry, Logbook, EntryLock
 from ..attachments import handle_img_tags
-from ..export import export_entries_as_pdf
+from ..export import export_entries_as_pdf, export_entries_as_html
 from ..actions import new_entry, edit_entry
 from . import fields, send_signal
 
@@ -195,6 +195,16 @@ class EntriesResource(Resource):
             return send_file(pdf, mimetype="application/pdf",
                              as_attachment=True,
                              attachment_filename=("{logbook.name}.pdf"
+                                                  .format(logbook=logbook)))
+        elif args.get("download") == "html":
+            # return a PDF version
+            # TODO: not sure if this belongs in the API
+            html = export_entries_as_html(logbook, entries)
+            if html is None:
+                abort(400, message="Could not create HTML!")
+            return send_file(html, mimetype="text/html",
+                             as_attachment=True,
+                             attachment_filename=("{logbook.name}.html"
                                                   .format(logbook=logbook)))
 
         return marshal(dict(logbook=logbook,

--- a/backend/backend/api/entries.py
+++ b/backend/backend/api/entries.py
@@ -203,12 +203,10 @@ class EntriesResource(Resource):
             html = export_entries_as_html(logbook, entries)
             if html is None:
                 abort(400, message="Could not create HTML!")
-            ret = send_file(html.name, mimetype="text/html",
+            return send_file(html, mimetype="text/html",
                              as_attachment=True,
                              attachment_filename=(slugify("{logbook.name}.html"
                                                   .format(logbook=logbook))))
-            html.close()
-            return ret
 
         return marshal(dict(logbook=logbook,
                             entries=list(entries)), fields.entries)

--- a/backend/backend/app.py
+++ b/backend/backend/app.py
@@ -4,9 +4,8 @@ The main entrypoint of the Elogy web application
 
 from time import time
 
-from flask import Flask, current_app, send_from_directory, g, request
+from flask import Flask, current_app, send_from_directory, g
 from flask_restful import Api
-import logging
 
 from .api.errors import errors as api_errors
 from .api.logbooks import LogbooksResource, LogbookChangesResource
@@ -23,7 +22,7 @@ app = Flask(__name__,
             static_folder="frontend/build/static",
             static_url_path="/static")
 app.config.from_envvar('ELOGY_CONFIG_FILE')
-
+app.root_path = app.config["ROOT_PATH"]
 app.secret_key = app.config["SECRET"]
 
 # add some hooks for debugging purposes

--- a/backend/backend/db.py
+++ b/backend/backend/db.py
@@ -571,7 +571,7 @@ class Entry(Model):
                attribute_filter=None, content_filter=None,
                title_filter=None, author_filter=None,
                attachment_filter=None, metadata_filter=None,
-               sort_by_timestamp=True):
+               sort_by_timestamp=True, reverse_order=False):
 
         # Note: this is all pretty messy. The reason we're building
         # the query as a raw string is that peewee does not (currently)
@@ -739,7 +739,8 @@ class Entry(Model):
 
         # Check if we're searching, in that case we want to show all entries.
         if followups or any([title_filter, content_filter, author_filter,
-                             metadata_filter, attribute_filter, attachment_filter]):
+                             metadata_filter, attribute_filter,
+                             attachment_filter]):
             query += " GROUP BY thread"
         else:
             # We're not searching. In this case we'll only show
@@ -748,7 +749,9 @@ class Entry(Model):
         # sort newest first, taking into account the last edit if any
         # TODO: does this make sense? Should we only consider creation date?
         order_by = sort_by_timestamp and "timestamp" or "entry.created_at"
-        query += " ORDER BY entry.priority DESC, {} DESC".format(order_by)
+        ordering = "DESC" if reverse_order else "ASC"
+        query += " ORDER BY entry.priority DESC, {} {}".format(order_by,
+                                                               ordering)
         if n:
             query += " LIMIT {}".format(n)
             if offset:

--- a/backend/backend/export.py
+++ b/backend/backend/export.py
@@ -1,4 +1,5 @@
 from tempfile import NamedTemporaryFile
+from slugify import slugify
 
 try:
     import pdfkit
@@ -62,10 +63,10 @@ def export_entries_as_html(logbook, entries):
 
     entries_html = [
         """
-        <p><b>Created at:</b> {created_at}</p>
-        <p><b>Title:</b> {title}</p>
-        <p><b>Authors:</b> {authors}</p>
-        <p>{content}</p>
+        <div><b>Created at:</b> {created_at}</div>
+        <div><b>Title:</b> {title}</div>
+        <div><b>Authors:</b> {authors}</div>
+        <div>{content}</div>
         <hr/>
         """.format(title=entry.title or "(No title)",
                    authors=", ".join(a["name"] for a in entry.authors),
@@ -73,10 +74,12 @@ def export_entries_as_html(logbook, entries):
                    content=entry.content or "---")
         for entry in entries
     ]
-    with NamedTemporaryFile(prefix=logbook.name,
+    print(entries_html)
+    with NamedTemporaryFile(prefix=slugify(logbook.name),
                             suffix=".html",
-                            delete=False) as f:
-        f.write('<h1>{}</h1><hr/>'.format(logbook.name).encode('utf8'))
+                            delete=True) as f:
+        f.write('<h1>{}</h1>'.format(logbook.name).encode('utf8'))
+        f.write('<div>{}</div><hr/>'.format(logbook.description).encode('utf8'))
         for entry_html in entries_html:
             f.write(entry_html.encode('utf8'))
-    return f.name
+    return f

--- a/backend/backend/export.py
+++ b/backend/backend/export.py
@@ -52,3 +52,31 @@ def export_entries_as_pdf(logbook, entries):
             # https://github.com/wkhtmltopdf/wkhtmltopdf/issues/2051
             pass
         return f.name
+
+def export_entries_as_html(logbook, entries):
+
+    """
+    Super basic "proof-of-concept" html export
+    No proper formatting, and does not embed images.
+    """
+
+    entries_html = [
+        """
+        <p><b>Created at:</b> {created_at}</p>
+        <p><b>Title:</b> {title}</p>
+        <p><b>Authors:</b> {authors}</p>
+        <p>{content}</p>
+        <hr/>
+        """.format(title=entry.title or "(No title)",
+                   authors=", ".join(a["name"] for a in entry.authors),
+                   created_at=entry.created_at,
+                   content=entry.content or "---")
+        for entry in entries
+    ]
+    with NamedTemporaryFile(prefix=logbook.name,
+                            suffix=".html",
+                            delete=False) as f:
+        f.write('<h1>{}</h1><hr/>'.format(logbook.name).encode('utf8'))
+        for entry_html in entries_html:
+            f.write(entry_html.encode('utf8'))
+    return f.name

--- a/backend/backend/export.py
+++ b/backend/backend/export.py
@@ -77,9 +77,10 @@ def export_entries_as_html(logbook, entries):
     print(entries_html)
     with NamedTemporaryFile(prefix=slugify(logbook.name),
                             suffix=".html",
-                            delete=True) as f:
+                            delete=False) as f:
         f.write('<h1>{}</h1>'.format(logbook.name).encode('utf8'))
         f.write('<div>{}</div><hr/>'.format(logbook.description).encode('utf8'))
         for entry_html in entries_html:
             f.write(entry_html.encode('utf8'))
-    return f
+        f.close()
+    return f.name

--- a/backend/config.py
+++ b/backend/config.py
@@ -5,6 +5,8 @@ TITLE = os.getenv('ELOGY_TITLE', 'elogy')
 
 BASEURL = os.getenv('ELOGY_URL', 'https://elogy.maxiv.lu.se')
 
+ROOT_PATH = os.getenv('ELOGY_ROOT', '')
+
 DEBUG = bool(os.getenv('ELOGY_DEBUG', 1))  # !!!Change this to False for production use!!!
 
 # The name of the database file

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -22,3 +22,4 @@ webargs==1.8.1
 Werkzeug==0.14.1
 wtf-peewee==0.2.6
 WTForms==2.1
+pdfkit==0.6.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,6 +14,7 @@ peewee==2.10.2
 Pillow==5.0.0
 pyldap==2.4.45
 python-dateutil==2.6.1
+python-slugify==2.0.1
 pytz==2017.3
 six==1.11.0
 uWSGI==2.0.15

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -18,7 +18,9 @@ setup(
         'flask-restful',
         'pyldap',  # should be optional, depends on libpdap and libsasl!
         'flask-admin',  # maybe also optional?
-        'wtf-peewee'
+        'wtf-peewee',
+        'python-slugify',  # optional, only used for file export
+        'pdfkit'  # optional, for export and depends on wkhtmltopdf
     ],
     extras_require={
         "dev": [

--- a/backend/templates/entry_export.html.jinja2
+++ b/backend/templates/entry_export.html.jinja2
@@ -1,0 +1,77 @@
+<title>'{{logbook.name}}', entries {{offset}}-{{offset+n}}</title>
+
+<head>
+    <meta charset="utf-8">
+</head>
+
+<style>
+ header {
+     background: #bdf;
+     border: 1px solid black;
+     padding: 10px;
+     line-height: 2em;
+     margin-bottom: 20px;
+ }
+ article {
+     border: 1px solid black;
+     margin-bottom: 30px;
+ }
+ .info {
+     background: #ddd;
+     border-bottom: 1px solid black;
+     padding: 10px;
+     line-height: 2em;
+ }
+ .content {
+     padding: 10px 2%;
+ }
+ .followup {
+     margin: 20px;
+ }
+ img {
+     max-width: 100%;
+ }
+</style>
+
+
+{% macro render_entry(logbook, entry, embed) %}
+    <article>
+        <div class="info">
+            <div>
+                <b>Entry:</b> <a name="{{entry.id}}">#{{entry.id}}</a>
+                {% if entry.follows %} (Follows <a href="#{{entry.follows_id}}">#{{entry.follows_id}})</a>{% endif %}
+            </div>
+            <div>
+                <b>Created at:</b> {{ entry.created_at }}
+                {%- if entry.last_changed_at -%},
+                    <b>Last modified at:</b> {{ entry.last_changed_at }}</b>
+                {% endif %}
+            </div>
+            <div><b>Title:</b> {{ entry.title }}</div>
+            <div><b>Authors:</b> {% for author in entry.authors %}{{ author.name }}{{", " if not loop.last else ""}}{% endfor %}</div>
+        </div>
+        <div class="content">{{ embed(entry.content) }}</div>
+
+        {% for followup in entry.followups %}
+            <div class="followup">
+                {{ render_entry(logbook, followup, embed) }}
+            </div>
+        {% endfor %}
+    </article>
+{% endmacro %}
+
+
+<body>
+    <header>
+        <h1>{{ logbook.name }}</h1>
+        <div>{{ logbook.description or "(No description)" }}</div>
+        <div>Exported from Elogy at {{ url_for("entriesresource", logbook_id=logbook.id, _external=True) }} on <time>{{export_time}}</time>. </div>
+    </header>
+
+
+    <main>
+    {% for entry in entries %}
+        {{ render_entry(logbook, entry, embed) }}
+    {% endfor %}
+    </main>
+</body>

--- a/frontend/src/logbook.js
+++ b/frontend/src/logbook.js
@@ -264,6 +264,17 @@ class Logbook extends React.Component {
                                     Configure
                                 </Link>{" "}
                                 |&nbsp;
+                                <Link
+                                    to={{
+                                        pathname: `/api/logbooks/${logbook.id}/entries/?download=html`,
+                                        search: window.location.search
+                                    }}
+                                    title={`Export the logbook '${logbook.name}' to html`}
+                                    target="_blank"
+                                >
+                                    Export HTML
+                                </Link>{" "}
+                                |&nbsp;
                             </span>
                         ) : null}
                         <Link

--- a/scripts/export_logbook_as_html.py
+++ b/scripts/export_logbook_as_html.py
@@ -1,0 +1,83 @@
+"""
+This script downloads a HTML version of a given logbook.
+Useful e.g. for letting users bring their logbook notes home.
+"""
+
+from argparse import ArgumentParser
+from itertools import count
+import os
+import re
+import shutil
+from time import sleep
+from tempfile import TemporaryDirectory
+from zipfile import ZipFile, ZIP_DEFLATED
+
+from requests import Session
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument("elogy_url",
+                        help="Base URL to the Elogy instance.")
+    parser.add_argument("logbook_id",
+                        help="Id (a number) of the logbook to export.")
+    parser.add_argument("-o", "--out",
+                        help="Name of the directory to put the exported HTML files in. Default: logbook_<id>")
+    parser.add_argument("-n", type=int, default=100,
+                        help="Number of entries to render per HTML file.")
+    parser.add_argument("-z", "--zip", action="store_true",
+                        help="Instead of a directory, create a zip file of the same name.")
+    args = parser.parse_args()
+
+    logbook_url = "{args.elogy_url}/api/logbooks/{args.logbook_id}/entries/".format(args=args)
+
+    dirname = args.out or "logbook_{args.logbook_id}".format(args=args)
+
+    session = Session()
+
+    with TemporaryDirectory() as tmpdir:
+
+        html_filenames = []
+
+        print("Downloading HTML exports...")
+        for i in count():
+            print(" - Batch {}...".format(i))
+            params = dict(
+                download="html",
+                n=args.n,
+                offset=args.n * i,
+                reverse_order=False  # chronological order makes more sense here..?
+            )
+            response = session.get(logbook_url, params=params)
+            if response.status_code == 200:
+                disp = response.headers['content-disposition']
+                filename, = re.findall("filename=(.+)", disp)
+                html_filenames.append(filename)
+                with open(os.path.join(tmpdir, filename), "w") as f:
+                    f.write(response.text)
+            elif response.status_code == 400:
+                break
+            else:
+                print("An error occurred (code %d): %r", response.status_code, response.text)
+                os.exit(1)
+            sleep(0.2)  # Give server some breathing room :)
+
+        with open(os.path.join(tmpdir, "index.html"), "w") as f:
+            f.writelines([
+                "<body>\n",
+                "  <ul>\n",
+                *("    <li><a href={f}>{f}</a></li>\n".format(f=f) for f in html_filenames),
+                "  </ul>\n"
+                "</body>"
+            ])
+
+        if args.zip:
+            zip_file = dirname + ".zip"
+            print("Zipping data into destination '{}'...".format(zip_file))
+            with ZipFile(zip_file, mode="w", compression=ZIP_DEFLATED) as zf:
+                zf.write(os.path.join(tmpdir, "index.html"), os.path.join(dirname, "index.html"))
+                for filename in html_filenames:
+                    zf.write(os.path.join(tmpdir, filename), os.path.join(dirname, filename))
+        else:
+            print("Putting results in destination '{}'...".format(dirname))
+            shutil.copytree(tmpdir, dirname)


### PR DESCRIPTION
Should solve issue #4, and replaces PR #9 (which it also builds upon. Thanks @dschick!). 

There was a very simple PDF export feature in Elogy before, but it was barely usable; formatting was very simple and it did not include images. This PR fixes those things and adds a HTML export.

The feature can be used like this:
`$ curl -OJ "http://elogy/api/logbooks/1/entries/?download=html&reverse_order=false&n=10"`

This should produce a HTML file containing the first ten entries in logbook 1, named after the logbook and the current time. The "download" parameter can be set to "html" or "pdf". The usual filtering options are also available.

There's also a simple helper script included, to export a whole logbook to a zipped file. The idea is that exporting a very large logbook might take some time - probably not more than some seconds but still, it will lock up the server meanwhile - so it's better to export it incrementally. 

Formatting of the HTML is still not great (see `templates/entry_export.html.jinja2`), feedback would be appreciated. Also, testing is needed as I had to make a few changes to the config.